### PR TITLE
git to da choppa again

### DIFF
--- a/.bash_functions.d/ssh
+++ b/.bash_functions.d/ssh
@@ -61,5 +61,5 @@ ssh-auth-sock() {
     echo export SSH_AUTH_SOCK=$( \
         ls /var/folders/*/*/T//ssh-*/agent.* \
            /private/tmp/com.apple.launchd.*/Listeners \
-        | head -n 1)
+           2>/dev/null | head -n 1)
 }

--- a/.gitconfig
+++ b/.gitconfig
@@ -16,7 +16,7 @@
 	rb = for-each-ref --sort=committerdate refs/heads/ --format='%(HEAD) %(color:yellow)%(refname:short)%(color:reset) - %(color:red)%(objectname:short)%(color:reset) - %(contents:subject) - %(authorname) (%(color:green)%(committerdate:relative)%(color:reset))'
   subup = !git submodule sync && git submodule update --init --recursive
   sha = rev-parse HEAD
-	to = push
+  to = push
 
 [core]
   excludesfile = /home/jgmize/.gitignore_global


### PR DESCRIPTION
```
$ git to da choppa
Enumerating objects: 11, done.
Counting objects: 100% (11/11), done.
Delta compression using up to 8 threads
Compressing objects: 100% (7/7), done.
Writing objects: 100% (7/7), 676 bytes | 676.00 KiB/s, done.
Total 7 (delta 5), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (5/5), completed with 4 local objects.
To github.com:jgmize/dotfiles.git
   df25e81..1c3fe67  choppa -> choppa
```